### PR TITLE
Replicate invalid logup-sum task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,25 @@ assumevalid-prove-rec:
 		--proof-format cairo-serde \
 		--verify
 
+replicate-invalid-logup-sum:
+	mkdir -p target/execute/assumevalid/invalid-logup-sum
+	cairo-execute \
+		--layout all_cairo_stwo \
+		--args-file  packages/assumevalid/tests/data/invalid-logup-sum-arguments.json \
+		--prebuilt \
+		--output-path target/execute/assumevalid/invalid-logup-sum/cairo_pie.zip \
+		target/proving/assumevalid.executable.json
+	stwo-bootloader \
+		--pie target/execute/assumevalid/invalid-logup-sum/cairo_pie.zip \
+		--output-path target/execute/assumevalid/invalid-logup-sum
+	adapted_stwo \
+		--priv_json target/execute/assumevalid/invalid-logup-sum/priv.json \
+		--pub_json target/execute/assumevalid/invalid-logup-sum/pub.json \
+		--params_json packages/assumevalid/prover_params.json \
+		--proof_path target/execute/assumevalid/invalid-logup-sum/proof.json \
+		--proof-format cairo-serde \
+		--verify
+
 ########################################## PIPELINE ##########################################
 
 setup: install-system-packages create-venv install-python-dependencies

--- a/scripts/data/prove_pow.py
+++ b/scripts/data/prove_pow.py
@@ -249,6 +249,8 @@ def prove_batch(height, step):
             PROOF_DIR / f"{mode}_{height}.proof.json" if height > 0 else None
         )
 
+        logger.debug(f"{job_info} generating data...")
+
         # Batch data
         batch_file = TMP_DIR / f"{mode}_{height}_{step}.json"
         batch_data = generate_data(
@@ -259,6 +261,8 @@ def prove_batch(height, step):
             "blocks": batch_data["blocks"],
         }
         Path(batch_file).write_text(json.dumps(batch_args, indent=2))
+
+        logger.debug(f"{job_info} generating args...")
 
         # Arguments file
         args = generate_assumevalid_args(batch_file, previous_proof_file)


### PR DESCRIPTION
Replicates `invalid logup-sum` issue:
```
make install-cairo-execute install-cairo-bootloader install-stwo assumevalid-build
make replicate-invalid-logup-sum
```
