### PR TITLE
Remove Poseidon usage (use blake2s for chainstate)

### DIFF
--- a/packages/utils/src/blake2s_hasher.cairo
+++ b/packages/utils/src/blake2s_hasher.cairo
@@ -1,0 +1,81 @@
+use core::blake::{blake2s_compress, blake2s_finalize};
+use core::box::BoxImpl;
+use utils::numeric::u32x8_to_u256;
+
+/// BLAKE2s IV is the same as SHA-256 IV
+/// We modify the first word to pre-configure:
+/// IV[0] ^ 0x01010020 (config: no key, 32 bytes output).
+const BLAKE2S_256_INITIAL_STATE: [u32; 8] = [
+    0x6B08E647, 0xBB67AE85, 0x3C6EF372, 0xA54FF53A, 0x510E527F, 0x9B05688C, 0x1F83D9AB, 0x5BE0CD19,
+];
+
+/// Blake2s incremental state.
+#[derive(Debug, Drop, Copy)]
+pub struct Blake2sState {
+    pub(crate) h: Box<[u32; 8]>,
+    pub(crate) byte_len: u32,
+}
+
+#[generate_trait]
+pub impl Blake2sHasherImpl of Blake2sHasher {
+    /// Creates a new Blake2s hasher, initialized with the Blake2s 256-bit IV.
+    fn new() -> Blake2sState {
+        Blake2sState { h: BoxImpl::new(BLAKE2S_256_INITIAL_STATE), byte_len: 0 }
+    }
+
+    /// Updates the hasher with 64 bytes of data.
+    /// NOTE: u32 words are little-endian.
+    fn compress_block(ref self: Blake2sState, data: [u32; 16]) {
+        self.byte_len += 64;
+        self.h = blake2s_compress(self.h, self.byte_len, BoxImpl::new(data));
+    }
+
+    /// Pads the data to 16 words and finalizes the hash.
+    /// Data must contain no more than 16 words.
+    /// NOTE: u32 words are little-endian (both for input and digest).
+    fn finalize_block(ref self: Blake2sState, data: Span<u32>) -> Box<[u32; 8]> {
+        let mut buffer: Array<u32> = data.into();
+        let byte_len = self.byte_len + buffer.len() * 4;
+        // Pad the buffer to 16 words.
+        for _ in buffer.len()..16 {
+            buffer.append(0);
+        }
+        // If the passed data was larger than 16 words, we will fail here
+        let block = buffer.span().try_into().expect('Cast to @Blake2sInput failed');
+        blake2s_finalize(self.h, byte_len, *block)
+    }
+}
+
+/// Converts a Blake2s digest to a u256.
+/// Takes the words in the reversed order.
+/// If you use Rust/Python implementation, reinterpet reference digest as LE integer to compare.
+pub fn blake2s_digest_to_u256_le(digest: Box<[u32; 8]>) -> u256 {
+    let [a, b, c, d, e, f, g, h] = digest.unbox();
+    u32x8_to_u256([h, g, f, e, d, c, b, a])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_blake2s_hasher_empty() {
+        let mut hasher = Blake2sHasher::new();
+        let digest = hasher.finalize_block(array![].span());
+        let res = blake2s_digest_to_u256_le(digest);
+        assert_eq!(
+            res, 113047845297338535936082629575907534931834714830939814641088356107939732922729,
+        );
+    }
+
+    #[test]
+    fn test_blake2s_hasher() {
+        let mut hasher = Blake2sHasher::new();
+        hasher.compress_block([1; 16]);
+        let digest = hasher.finalize_block(array![2, 3, 4, 5, 6, 7].span());
+        let res = blake2s_digest_to_u256_le(digest);
+        assert_eq!(
+            res, 46893214958280054196873295526662987612846164852081208338716593733223283895883,
+        );
+    }
+}

--- a/packages/utils/src/lib.cairo
+++ b/packages/utils/src/lib.cairo
@@ -1,4 +1,5 @@
 pub mod bit_shifts;
+pub mod blake2s_hasher;
 pub mod bytearray;
 pub mod double_sha256;
 pub mod hash;

--- a/packages/utils/src/numeric.cairo
+++ b/packages/utils/src/numeric.cairo
@@ -2,6 +2,12 @@
 
 use crate::bit_shifts::shr_u64;
 
+const POW_2_32: u128 = 0x100000000;
+const POW_2_64: u128 = 0x10000000000000000;
+const POW_2_96: u128 = 0x1000000000000000000000000;
+const NZ_POW2_32_128: NonZero<u128> = 0x100000000;
+const NZ_POW2_32_64: NonZero<u64> = 0x100000000;
+
 /// Computes the next power of two of a `u64` variable.
 /// Returns 2^x, where x is the smallest integer such that 2^x >= n.
 pub fn u64_next_power_of_two(mut n: u64) -> u64 {
@@ -20,9 +26,41 @@ pub fn u64_next_power_of_two(mut n: u64) -> u64 {
     n + 1
 }
 
+
+/// Converts a `u256` value into a `[u32; 8]` array.
+pub fn u256_to_u32x8(value: u256) -> [u32; 8] {
+    let u256 { low, high } = value;
+
+    let (abc, d) = DivRem::div_rem(high, NZ_POW2_32_128);
+    let (ab, c) = DivRem::div_rem(abc, NZ_POW2_32_128);
+    let ab: u64 = ab.try_into().unwrap();
+    let (a, b) = DivRem::div_rem(ab, NZ_POW2_32_64);
+
+    let (efg, h) = DivRem::div_rem(low, NZ_POW2_32_128);
+    let (ef, g) = DivRem::div_rem(efg, NZ_POW2_32_128);
+    let ef: u64 = ef.try_into().unwrap();
+    let (e, f) = DivRem::div_rem(ef, NZ_POW2_32_64);
+
+    [
+        a.try_into().unwrap(), b.try_into().unwrap(), c.try_into().unwrap(), d.try_into().unwrap(),
+        e.try_into().unwrap(), f.try_into().unwrap(), g.try_into().unwrap(), h.try_into().unwrap(),
+    ]
+}
+
+
+/// Converts a `[u32; 8]` array into a `u256` value.
+pub fn u32x8_to_u256(value: [u32; 8]) -> u256 {
+    let [a, b, c, d, e, f, g, h] = value;
+
+    let high: u128 = a.into() * POW_2_96 + b.into() * POW_2_64 + c.into() * POW_2_32 + d.into();
+    let low: u128 = e.into() * POW_2_96 + f.into() * POW_2_64 + g.into() * POW_2_32 + h.into();
+
+    u256 { low, high }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::u64_next_power_of_two;
+    use super::*;
 
     #[test]
     fn test_u64_next_power_of_two() {
@@ -84,6 +122,29 @@ mod tests {
         let input: u64 = 1500000000000000000;
         let expected_output: u64 = 2305843009213693952;
         let result = u64_next_power_of_two(input);
+        assert_eq!(result, expected_output);
+    }
+
+    #[test]
+    fn test_u256_to_u32x8() {
+        let input: u256 = u256 {
+            high: 0x000102030405060708090a0b0c0d0e0f, low: 0x00112233445566778899aabbccddeeff,
+        };
+        let expected_output: [u32; 8] = [
+            0x00010203, 0x04050607, 0x08090a0b, 0x0c0d0e0f, 0x00112233, 0x44556677, 0x8899aabb,
+            0xccddeeff,
+        ];
+        let result = u256_to_u32x8(input);
+        assert_eq!(result, expected_output);
+    }
+
+    #[test]
+    fn test_u32x8_to_u256() {
+        let input: [u32; 8] = [1, 2, 3, 4, 5, 6, 7, 8];
+        let expected_output: u256 = u256 {
+            high: 0x00000001000000020000000300000004, low: 0x00000005000000060000000700000008,
+        };
+        let result = u32x8_to_u256(input);
         assert_eq!(result, expected_output);
     }
 }


### PR DESCRIPTION
Would allow to get rid of Poseidon component in Stwo (in the future optimizations).
Also introduces blake2s hasher which should be used instead of Poseidon in Utreexo and other hash accumulators.