### PR TITLE
Update install-system-packages target to detect Ubuntu 24.04 and install correct package.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,13 @@ setup: install-system-packages create-venv install-python-dependencies
 install-system-packages:
 	@echo ">>> Updating apt package list and installing system-level Python packages..."
 	sudo apt update
-	sudo apt install -y python3-pip python3.11-venv \
-		# Use -y for non-interactive install
+	@if [ "$$(lsb_release -rs | cut -d. -f1)" -ge "24" ]; then \
+		echo ">>> Detected Ubuntu 24.04+, using python3-venv"; \
+		sudo apt install -y python3-pip python3-venv; \
+	else \
+		echo ">>> Detected Ubuntu < 24.04, using python3.11-venv"; \
+		sudo apt install -y python3-pip python3.11-venv; \
+	fi
 
 create-venv:
 	@echo ">>> Creating Python virtual environment '.venv'..."


### PR DESCRIPTION
Update install-system-packages target to detect Ubuntu version and use appropriate Python venv package. 
Ubuntu 24.04+ uses python3-venv while other/older versions use python3.11-venv.

<!-- enter the gh issue after hash -->

- [ ] (no issue opened)
- [X] follows contribution [guide](https://github.com/keep-starknet-strange/raito/blob/main/CONTRIBUTING.md)
- [X] code change tests the OS version

<!-- PR description below -->

Problem

The current Makefile hardcodes python3.11-venv in the install-system-packages target, but Ubuntu 24.04 LTS no longer includes this package. Instead, Ubuntu 24.04+ uses the generic python3-venv package.

Current Behavior

When running make install-system-packages on Ubuntu 24.04, the installation fails with:
E: Unable to locate package python3.11-venv
E: Couldn't find any package by glob 'python3.11-venv'

Expected Behavior

The Makefile should automatically detect the Ubuntu version and install the appropriate Python venv package:
- Ubuntu 24.04+: python3-venv
- Other: fallback to python3.11-venv

Affected Code

Makefile line 91:
sudo apt install -y python3-pip python3.11-venv \

Environment

- Ubuntu 24.04.3 LTS
- Python 3.11 (environment installed with conda)

Proposed Solution

Add version detection logic to conditionally install the correct package based on the Ubuntu release version.
