### PR TITLE
Add chain state indexing and RPC endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ blake2 = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["arbitrary_precision"] }
 hex = "0.4"
+bincode = "1.3"
 
 # BigInt
 num-bigint = { version = "0.4", features = ["serde"] }

--- a/crates/raito-bridge-node/Cargo.toml
+++ b/crates/raito-bridge-node/Cargo.toml
@@ -22,6 +22,7 @@ tower-http = { version = "0.5", features = ["trace", "cors", "compression-gzip"]
 bitcoin.workspace = true
 # Storage
 sqlx.workspace = true
+bincode.workspace = true
 # CLI
 clap.workspace = true
 dotenv.workspace = true

--- a/crates/raito-bridge-node/src/chain_state.rs
+++ b/crates/raito-bridge-node/src/chain_state.rs
@@ -1,0 +1,111 @@
+use std::str::FromStr;
+use std::sync::Arc;
+
+use accumulators::store::StoreError;
+use async_trait::async_trait;
+use bitcoin::block::BlockHash;
+use bitcoin::block::Header as BlockHeader;
+use bitcoin::Target;
+use bitcoin::Work;
+use raito_spv_verify::ChainState;
+
+const BLOCKS_PER_EPOCH: u32 = 2016;
+
+#[async_trait]
+pub trait ChainStateStore: Send + Sync {
+    async fn add_block_header(
+        &self,
+        height: u32,
+        block_header: &BlockHeader,
+    ) -> Result<(), StoreError>;
+    async fn get_block_headers(
+        &self,
+        start_height: u32,
+        num_blocks: u32,
+    ) -> Result<Vec<BlockHeader>, StoreError>;
+    async fn get_block_height(&self, block_hash: &BlockHash) -> Result<u32, StoreError>;
+    async fn add_chain_state(
+        &self,
+        height: u32,
+        chain_state: &ChainState,
+    ) -> Result<(), StoreError>;
+    async fn get_chain_state(&self, height: u32) -> Result<ChainState, StoreError>;
+}
+
+pub struct ChainStateManager {
+    current_state: ChainState,
+    store: Arc<dyn ChainStateStore>,
+}
+
+impl ChainStateManager {
+    pub async fn restore(
+        store: Arc<dyn ChainStateStore>,
+        height: u32,
+    ) -> Result<Self, anyhow::Error> {
+        let current_state = if height == 0 {
+            Self::genesis_state()
+        } else {
+            store.get_chain_state(height - 1).await?
+        };
+        Ok(Self {
+            current_state,
+            store,
+        })
+    }
+
+    pub async fn update(
+        &mut self,
+        block_height: u32,
+        block_header: &BlockHeader,
+    ) -> Result<(), anyhow::Error> {
+        let new_state = if block_height == 0 {
+            self.current_state.clone()
+        } else {
+            let mut prev_timestamps = self.current_state.prev_timestamps.clone();
+            prev_timestamps.push(block_header.time);
+            if prev_timestamps.len() > 11 {
+                prev_timestamps.remove(0);
+            }
+
+            let epoch_start_time = if block_height % BLOCKS_PER_EPOCH == 0 {
+                block_header.time
+            } else {
+                self.current_state.epoch_start_time
+            };
+
+            ChainState {
+                block_height,
+                total_work: self.current_state.total_work + block_header.work(),
+                best_block_hash: block_header.block_hash(),
+                current_target: block_header.target(),
+                epoch_start_time,
+                prev_timestamps,
+            }
+        };
+
+        self.store.add_chain_state(block_height, &new_state).await?;
+        self.store
+            .add_block_header(block_height, block_header)
+            .await?;
+        self.current_state = new_state;
+
+        Ok(())
+    }
+
+    pub fn genesis_state() -> ChainState {
+        ChainState {
+            block_height: 0,
+            total_work: Work::from_hex("0x100010001").unwrap(),
+            best_block_hash: BlockHash::from_str(
+                "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+            )
+            .unwrap(),
+            current_target: Target::from_hex(
+                "0xffff0000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+            epoch_start_time: 1231006505,
+            prev_timestamps: vec![1231006505],
+        }
+    }
+}

--- a/crates/raito-bridge-node/src/main.rs
+++ b/crates/raito-bridge-node/src/main.rs
@@ -13,6 +13,7 @@ use crate::{
     shutdown::Shutdown,
 };
 
+mod chain_state;
 mod indexer;
 mod rpc;
 mod shutdown;

--- a/crates/raito-spv-client/Cargo.toml
+++ b/crates/raito-spv-client/Cargo.toml
@@ -41,7 +41,7 @@ starknet-ff = "0.3.7"
 hex = "0.4.3"
 serde = { workspace = true }
 serde_json = { workspace = true }
-bincode = "1.3"
+bincode = { workspace = true }
 
 # Compression
 bzip2 = "0.4"

--- a/crates/raito-spv-verify/src/work.rs
+++ b/crates/raito-spv-verify/src/work.rs
@@ -20,13 +20,13 @@ pub fn verify_subchain_work(
     let start_epoch = chain_state.block_height / 2016;
     let end_epoch = block_height / 2016;
     let mut subchain_work = BigUint::ZERO;
-    let mut target = BigUint::from_str(&chain_state.current_target).unwrap();
+    let mut target = BigUint::from_bytes_be(&chain_state.current_target.to_be_bytes());
 
     for epoch in (end_epoch..=start_epoch).rev() {
         let start_block = min(2016 * (epoch + 1), chain_state.block_height);
         let end_block = max(2016 * epoch, block_height);
         let block_span = BigUint::from(start_block - end_block);
-        let block_work = compute_work_from_target(target.clone());
+        let block_work = compute_work_from_target(&target);
         subchain_work += block_work * block_span;
         target *= BigUint::from(4_u32);
     }
@@ -48,7 +48,7 @@ pub fn verify_subchain_work(
 }
 
 /// Compute the expected work for a single block given the target difficulty.
-fn compute_work_from_target(target: BigUint) -> BigUint {
+fn compute_work_from_target(target: &BigUint) -> BigUint {
     // 2^256
     let max_work = BigUint::from_str(
         "115792089237316195423570985008687907853269984665640564039457584007913129639936",


### PR DESCRIPTION
# Add Chain State Management

This PR adds a chain state management system to track and maintain the Bitcoin chain state, which is essential for SPV verification. The implementation includes:

- New `ChainState` struct to store block height, total work, best block hash, current target, epoch start time, and previous timestamps
- `ChainStateManager` to handle state updates when new blocks are processed
- SQLite storage for chain states with serialization using bincode
- New RPC endpoint `/chain-state/:block_height` to retrieve chain state at a specific height
- Integration with the indexer to update chain state alongside MMR updates
- Refactored block header storage to separate it from MMR functionality

These changes enable proper tracking of chain parameters needed for SPV verification and provide a way for clients to access this information through the API.